### PR TITLE
Reservations API: get reservation by id

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -2,27 +2,15 @@ from fastapi import FastAPI
 
 from app.routers.auth import router as auth_router
 from app.routers.me import router as me_router
-<<<<<<< feat/5-reservations-create-prevent-overlaps
 from app.routers.reservations import router as reservations_router
-=======
 from app.routers.facilities import router as facilities_router
->>>>>>> main
-
-
-
-from app.routers.reservations import router as reservations_router
 
 app = FastAPI(title="MPI Court Reservations")
+
 app.include_router(auth_router)
 app.include_router(me_router)
-<<<<<<< feat/5-reservations-create-prevent-overlaps
 app.include_router(reservations_router)
-=======
 app.include_router(facilities_router)
->>>>>>> main
-
-
-app.include_router(reservations_router)
 
 
 @app.get("/health")

--- a/backend/app/routers/reservations.py
+++ b/backend/app/routers/reservations.py
@@ -2,19 +2,12 @@ from __future__ import annotations
 
 from typing import List
 
-from fastapi import APIRouter, Depends
-from sqlalchemy.orm import Session
-from fastapi import HTTPException, status
-
-from app.db import get_db
-from app.security import get_current_user
-from app import models, schemas
 from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy.orm import Session
 
 from app import models, schemas
 from app.db import get_db
-from app.security import get_current_user  # trebuie să existe deja
+from app.security import get_current_user
 
 router = APIRouter(prefix="/reservations", tags=["reservations"])
 
@@ -30,8 +23,35 @@ def list_my_reservations(
         .order_by(models.Reservation.start_time.asc())
         .all()
     )
-    # dacă nu are rezervări -> [] (200 OK), automat
     return [schemas.ReservationResponse.model_validate(r) for r in reservations]
+
+
+@router.get("/{reservation_id}", response_model=schemas.ReservationResponse)
+def get_reservation_by_id(
+    reservation_id: int,
+    db: Session = Depends(get_db),
+    current_user: models.User = Depends(get_current_user),
+) -> schemas.ReservationResponse:
+    reservation = (
+        db.query(models.Reservation)
+        .filter(models.Reservation.id == reservation_id)
+        .first()
+    )
+
+    if reservation is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Reservation not found",
+        )
+
+    if reservation.user_id != current_user.id:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Forbidden",
+        )
+
+    return schemas.ReservationResponse.model_validate(reservation)
+
 
 @router.delete("/{reservation_id}", response_model=schemas.ReservationResponse, status_code=status.HTTP_200_OK)
 def cancel_reservation(
@@ -46,27 +66,26 @@ def cancel_reservation(
     if reservation.user_id != current_user.id:
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Forbidden")
 
-    # idempotent behavior: if already canceled, return it as-is (still 200)
     if reservation.status != "canceled":
         reservation.status = "canceled"
         db.commit()
         db.refresh(reservation)
 
     return schemas.ReservationResponse.model_validate(reservation)
+
+
 @router.post("", response_model=schemas.ReservationResponse, status_code=status.HTTP_201_CREATED)
 def create_reservation(
     payload: schemas.ReservationCreateRequest,
     db: Session = Depends(get_db),
     current_user: models.User = Depends(get_current_user),
 ) -> schemas.ReservationResponse:
-    # 1) validate time window
     if payload.start_time >= payload.end_time:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="start_time must be earlier than end_time",
         )
 
-    # 2) ensure facility exists
     facility = db.query(models.Facility).filter(models.Facility.id == payload.facility_id).first()
     if not facility:
         raise HTTPException(
@@ -74,8 +93,6 @@ def create_reservation(
             detail="Facility not found",
         )
 
-    # 3) overlap check:
-    # overlap if existing.start < new.end AND existing.end > new.start
     overlapping = (
         db.query(models.Reservation)
         .filter(models.Reservation.facility_id == payload.facility_id)
@@ -90,7 +107,6 @@ def create_reservation(
             detail="Time slot is already booked for this facility",
         )
 
-    # 4) create reservation (user_id from token, NOT from client)
     reservation = models.Reservation(
         user_id=current_user.id,
         facility_id=payload.facility_id,

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
+
 from datetime import datetime
-from pydantic import BaseModel, EmailStr, Field
 from typing import Optional
+
+from pydantic import BaseModel, EmailStr, Field
 
 
 class RegisterRequest(BaseModel):
@@ -27,12 +29,12 @@ class UserResponse(BaseModel):
     class Config:
         from_attributes = True
 
-class ReservationResponse(BaseModel):
-    id: int
+
 class ReservationCreateRequest(BaseModel):
     facility_id: int = Field(gt=0)
     start_time: datetime
     end_time: datetime
+
 
 class ReservationResponse(BaseModel):
     id: int
@@ -42,6 +44,11 @@ class ReservationResponse(BaseModel):
     end_time: datetime
     status: str
     created_at: datetime
+
+    class Config:
+        from_attributes = True
+
+
 class FacilityResponse(BaseModel):
     id: int
     name: str


### PR DESCRIPTION
Closes #25

## Summary

Add `GET /reservations/{id}` for authenticated users and enforce reservation ownership when fetching a single reservation.

## Behavior (Acceptance Criteria)

- `GET /reservations/{id}` requires authentication
- Returns `200 OK` with reservation JSON when the reservation belongs to the authenticated user
- Returns `403 Forbidden` when the reservation belongs to another user
- Returns `404 Not Found` when the reservation does not exist
- Response includes at least: `id`, `facility_id`, `start_time`, `end_time`, `status`, `created_at`
- Errors are returned in JSON format

## Manual testing

- Started the backend locally with `uvicorn app.main:app --reload`
- Verified authenticated request to `GET /reservations/{id}` returns `200 OK` for the owner
- Verified authenticated request to another user's reservation returns `403 Forbidden`
- Verified request to a missing reservation returns `404 Not Found`
- Verified the endpoint is visible in Swagger at `/docs`

## Notes / Follow-ups

- Cleaned duplicated imports and router registration in `main.py`
- Cleaned duplicated reservation schema definitions in `schemas.py`