### PR TITLE
DevOps: environment configuration standard (.env.example + validation)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,9 @@ pytest-report.xml
 
 .env
 .env.*
+backend/.env
+.env.local
+backend/.env.local
 *.secrets.*
 *.key
 *.pem

--- a/Makefile
+++ b/Makefile
@@ -13,4 +13,4 @@ migrate:
 	cd $(BACKEND_DIR) && alembic upgrade head
 
 run:
-	cd $(BACKEND_DIR) && uvicorn main:app --reload
+	cd backend && uvicorn main:app --reload --env-file .env

--- a/README.md
+++ b/README.md
@@ -79,3 +79,11 @@ Clone the repository and start the local services:
 git clone https://github.com/NovaNode-MPI/mpi-court-reservations.git
 cd mpi-court-reservations
 make up
+
+
+### Backend environment setup
+
+Before running the backend locally, create a local environment file:
+
+```bash
+cp backend/.env.example backend/.env

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,13 +1,10 @@
 from __future__ import annotations
 
+from contextlib import asynccontextmanager
+
 from fastapi import Depends, FastAPI, HTTPException, Request
 from fastapi.exceptions import RequestValidationError
 from fastapi.middleware.cors import CORSMiddleware
-from fastapi import FastAPI
-from fastapi.middleware.cors import CORSMiddleware
-
-from app.config import CORS_ORIGINS
-from fastapi import Depends, FastAPI
 from fastapi.responses import JSONResponse
 from sqlalchemy import text
 from sqlalchemy.exc import SQLAlchemyError
@@ -17,17 +14,22 @@ from app import schemas
 from app.config import CORS_ORIGINS
 from app.db import get_db
 from app.routers.auth import router as auth_router
+from app.routers.facilities import router as facilities_router
 from app.routers.me import router as me_router
 from app.routers.reservations import router as reservations_router
-from app.routers.facilities import router as facilities_router
-
-from contextlib import asynccontextmanager
-from fastapi import FastAPI
 from env_validation import validate_env
 
-validate_env()
 
-app = FastAPI(title="MPI Court Reservations")
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    validate_env()
+    yield
+
+
+app = FastAPI(
+    title="MPI Court Reservations",
+    lifespan=lifespan,
+)
 
 app.add_middleware(
     CORSMiddleware,
@@ -137,16 +139,6 @@ def health_db(db: Session = Depends(get_db)):
     except SQLAlchemyError:
         return _error_response(
             status_code=503,
-            content={"status": "error", "db": "unavailable"},
-        )
-    
-@asynccontextmanager
-async def lifespan(app: FastAPI):
-    validate_env()
-    yield
-
-
-app = FastAPI(lifespan=lifespan)
             error_code="service_unavailable",
             message="Database unavailable",
             details=None,

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -14,6 +14,12 @@ from app.routers.me import router as me_router
 from app.routers.reservations import router as reservations_router
 from app.routers.facilities import router as facilities_router
 
+from contextlib import asynccontextmanager
+from fastapi import FastAPI
+from env_validation import validate_env
+
+validate_env()
+
 app = FastAPI(title="MPI Court Reservations")
 
 app.add_middleware(
@@ -45,3 +51,11 @@ def health_db(db: Session = Depends(get_db)):
             status_code=503,
             content={"status": "error", "db": "unavailable"},
         )
+    
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    validate_env()
+    yield
+
+
+app = FastAPI(lifespan=lifespan)

--- a/backend/env_validation.py
+++ b/backend/env_validation.py
@@ -1,0 +1,40 @@
+import os
+
+REQUIRED_ENV_VARS = [
+    "DATABASE_URL",
+    "JWT_SECRET_KEY",
+    "JWT_ALGORITHM",
+    "ACCESS_TOKEN_EXPIRE_MINUTES",
+]
+
+
+def validate_env() -> None:
+    missing = []
+
+    for var_name in REQUIRED_ENV_VARS:
+        value = os.getenv(var_name)
+        if value is None or value.strip() == "":
+            missing.append(var_name)
+
+    errors = []
+
+    if missing:
+        errors.append(
+            "Missing required environment variables: " + ", ".join(missing)
+        )
+
+    access_token_expire = os.getenv("ACCESS_TOKEN_EXPIRE_MINUTES")
+    if access_token_expire is not None and access_token_expire.strip() != "":
+        try:
+            expire_minutes = int(access_token_expire)
+            if expire_minutes <= 0:
+                errors.append(
+                    "ACCESS_TOKEN_EXPIRE_MINUTES must be a positive integer."
+                )
+        except ValueError:
+            errors.append(
+                "ACCESS_TOKEN_EXPIRE_MINUTES must be an integer."
+            )
+
+    if errors:
+        raise RuntimeError("Environment configuration error. " + " ".join(errors))


### PR DESCRIPTION
## Summary
Adds a standard backend environment configuration setup using `.env.example` and startup validation so contributors can run the project without guessing required variables.

## Behavior (Acceptance Criteria)
- Adds `backend/.env.example` with all required variables:
  - `DATABASE_URL`
  - `JWT_SECRET_KEY`
  - `JWT_ALGORITHM`
  - `ACCESS_TOKEN_EXPIRE_MINUTES`
- Ensures local `.env` files are gitignored
- Adds minimal runtime validation during app startup
- Fails fast with a clear error message when required variables are missing or invalid

## Manual testing
- Added `backend/.env.example` with the required backend variables
- Verified `.env` is ignored by Git
- Started the backend with valid environment variables and confirmed startup succeeds
- Tested startup with missing variables and confirmed the app fails fast with a clear error message
- Tested invalid `ACCESS_TOKEN_EXPIRE_MINUTES` and confirmed validation fails clearly

## Notes / Follow-ups
- The local `make run` command was updated to use `--env-file .env` for easier local startup
- Docker Compose environment values remain unchanged and continue to work for container-based development

Closes #41