### PR TITLE
QA: choose testing approach + tools (unit/integration/e2e)

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,14 +7,17 @@ A simple booking platform that allows users to reserve sports facilities (courts
 ## 1. Description & Objectives
 
 ### Description
+
 Sports facilities are often booked informally (messages/phone calls), which can lead to double bookings, lack of transparency, and difficulties in tracking reservations.
 
 ### Objectives
+
 - Provide a clear reservation flow: register/login → browse facilities → book → view/cancel.
 - Prevent overlapping reservations for the same facility and time interval.
 - Use a clean ALM process (Issues, GitHub Projects, PR reviews, CI/CD, Docker, deployment).
 
 ### Target Users
+
 - Users who want to book a sports facility (tennis court, football field, etc.)
 - Facility managers (future enhancement) who want an overview of bookings
 
@@ -22,12 +25,12 @@ Sports facilities are often booked informally (messages/phone calls), which can 
 
 ## 2. Team & Roles
 
-| Student Name        | Champion Role            | GitHub Username        |
-|--------------------|--------------------------|------------------------|
-| Alexandra Scarlat  | Backend                  | @AlexandraScarlat15   |
-| Andra Stoica       | Frontend                 | @andrastefania        |
-| Elena Strugari     | DevOps / Infrastructure  | @Elena-Strugari       |
-| Mario Voicu        | QA / Testing             | @MarioAndreiVoicu     |
+| Student Name      | Champion Role           | GitHub Username     |
+| ----------------- | ----------------------- | ------------------- |
+| Alexandra Scarlat | Backend                 | @AlexandraScarlat15 |
+| Andra Stoica      | Frontend                | @andrastefania      |
+| Elena Strugari    | DevOps / Infrastructure | @Elena-Strugari     |
+| Mario Voicu       | QA / Testing            | @MarioAndreiVoicu   |
 
 Each champion owns the deliverables of their area. Implementation can be shared across the team.
 
@@ -42,10 +45,58 @@ Each champion owns the deliverables of their area. Implementation can be shared 
 - **Styling:** Plain CSS
 
 ### DevOps & Infrastructure
-- **Testing:** backend tests (minimum CI requirement)
+
 - **CI/CD:** GitHub Actions
 - **Docker:** Docker Compose (API + PostgreSQL)
 - **Deploy:** Render (planned MVP deployment platform)
+
+## Testing
+
+For M1, the project uses:
+
+- **Unit tests**: limited use for small isolated logic/helpers where appropriate
+- **Integration tests**: main automated testing level for the backend API
+- **E2E / smoke testing**: manual end-to-end validation of the MVP flow
+
+### Backend automated tests
+
+From the `backend` folder:
+
+```bash
+pytest
+```
+
+If needed, activate the virtual environment first and install dependencies:
+
+```bash
+python -m venv .venv
+.venv\Scripts\Activate.ps1
+pip install -r requirements.txt
+pytest
+```
+
+### Current automated coverage
+
+The current automated focus is backend integration testing, including:
+
+- authentication flows
+- reservation creation
+- overlap rejection
+- invalid interval rejection
+- ownership/authorization rules
+- listing only the authenticated user’s reservations
+
+### Minimum MVP smoke flow
+
+1. Register a new user
+2. Log in
+3. Open the facilities page
+4. Verify facilities are displayed
+5. Create a reservation
+6. Open **My Reservations**
+7. Verify the reservation is visible
+8. Cancel the reservation
+9. Verify the reservation status/behavior is updated correctly
 
 ---
 
@@ -66,6 +117,7 @@ The current or planned application features include:
 ## 5. Local Setup (How to run the project)
 
 ### Prerequisites
+
 Before running the project locally, make sure you have:
 
 - **Docker Desktop**
@@ -73,13 +125,14 @@ Before running the project locally, make sure you have:
 - the required backend dependencies installed in your local Python environment when using `make migrate` or `make run`
 
 ### Run with Docker Compose
+
 Clone the repository and start the local services:
 
 ```bash
 git clone https://github.com/NovaNode-MPI/mpi-court-reservations.git
 cd mpi-court-reservations
 make up
-
+```
 
 ### Backend environment setup
 
@@ -87,3 +140,4 @@ Before running the backend locally, create a local environment file:
 
 ```bash
 cp backend/.env.example backend/.env
+```

--- a/docs/testing-strategy.md
+++ b/docs/testing-strategy.md
@@ -1,0 +1,109 @@
+# Testing Strategy (M1 - MVP)
+
+## 1. Scope for M1
+
+For M1, we use three testing levels:
+
+- **Unit tests**: limited use for small isolated logic/helpers where appropriate.
+- **Integration tests**: main automated testing level for the backend API.
+- **E2E / smoke testing**: manual end-to-end validation of the MVP user flow.
+
+For M1, the priority is to verify that the backend API works correctly, that the main reservation rules are enforced, and that the basic user flow can be validated from the UI.
+
+## 2. Tools
+
+### Unit tests
+
+- **pytest**
+
+### Integration tests
+
+- **pytest**
+- **FastAPI TestClient**
+- **SQLite test database**
+- **pytest fixtures** for isolated setup and reusable helpers
+
+### E2E / smoke testing
+
+- **Manual browser testing** in local development
+
+## 3. What we test
+
+### Authentication
+
+- user registration with valid data
+- login with valid credentials
+- rejection of invalid credentials
+- authenticated access to protected endpoints
+
+### Reservations
+
+- valid reservation creation
+- rejection of overlapping reservations
+- rejection of invalid time intervals
+- ownership rules (a user cannot modify or cancel another user’s reservation)
+- listing only the authenticated user’s reservations
+
+### Facilities
+
+- listing available facilities
+- retrieving a facility by id
+
+## 4. Current automated test focus
+
+For M1, the main automated focus is **backend integration testing**.
+
+This matches the current backend test setup, which already uses:
+
+- `pytest`
+- FastAPI `TestClient`
+- a separate SQLite test database
+- fixtures/helpers in `conftest.py`
+
+Existing reservation tests already cover the main MVP backend rules:
+
+- valid reservation creation
+- overlap rejection
+- invalid interval rejection
+- ownership restrictions
+- per-user reservation listing
+
+## 5. How to run tests locally
+
+### Backend automated tests
+
+From the `backend` folder:
+
+```bash
+pytest
+```
+
+If needed, activate the virtual environment first and install dependencies:
+
+```bash
+python -m venv .venv
+.venv\Scripts\Activate.ps1
+pip install -r requirements.txt
+pytest
+```
+
+## 6. Minimum MVP smoke flow
+
+The minimum manual E2E flow for M1 is:
+
+1. Open the frontend application
+2. Register a new user
+3. Log in with that user
+4. Open the facilities page
+5. Verify facilities are displayed
+6. Create a reservation
+7. Open **My Reservations**
+8. Verify the reservation is visible
+9. Cancel the reservation
+10. Verify the reservation status/behavior is updated correctly
+
+## 7. Notes
+
+- Backend integration tests are the main reliable automated testing layer for M1.
+- Manual smoke testing is used for the MVP end-to-end flow.
+- A fuller automated E2E setup can be added in a later milestone after the frontend reservation flow is fully completed.


### PR DESCRIPTION
## Summary

- added `docs/testing-strategy.md`
- documented the M1 testing scope and chosen tools
- documented how to run backend tests locally
- documented the minimum MVP smoke flow
- updated the README testing section to match the chosen QA approach

## Behavior (Acceptance Criteria)

- testing levels for M1 are defined: unit, integration, and manual E2E/smoke testing
- tools for each testing level are documented
- `docs/testing-strategy.md` explains:
  - what we test
  - how to run tests locally
  - the minimum MVP E2E flow
- `README.md` now reflects the chosen testing approach/tools

## Manual testing

- reviewed `docs/testing-strategy.md`
- reviewed the updated `README.md`
- confirmed the branch contains only the documentation changes for this issue

Closes #13