### PR TITLE
QA: create Postman/Thunder Client collection for MVP endpoints

### DIFF
--- a/docs/api/mvp-api.postman_collection.json
+++ b/docs/api/mvp-api.postman_collection.json
@@ -1,0 +1,229 @@
+{
+  "info": {
+    "_postman_id": "5e0d3e84-3b7a-4a6b-a8ce-qa-mpi-mvp",
+    "name": "MPI Court Reservations - MVP API",
+    "description": "Postman collection for MVP endpoints: register, login, me, facilities, reservations, cancel reservation.",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+  },
+  "variable": [
+    { "key": "baseUrl", "value": "http://127.0.0.1:8000" },
+    { "key": "token", "value": "" },
+    { "key": "reservationId", "value": "" },
+    { "key": "email", "value": "usera@example.com" },
+    { "key": "password", "value": "password123" },
+    { "key": "facilityId", "value": "1" },
+    { "key": "startTime", "value": "2026-05-01T10:00:00Z" },
+    { "key": "endTime", "value": "2026-05-01T11:00:00Z" }
+  ],
+  "item": [
+    {
+      "name": "Auth",
+      "item": [
+        {
+          "name": "Register",
+          "request": {
+            "method": "POST",
+            "header": [{ "key": "Content-Type", "value": "application/json" }],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"email\": \"{{email}}\",\n  \"password\": \"{{password}}\"\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/auth/register",
+              "host": ["{{baseUrl}}"],
+              "path": ["auth", "register"]
+            },
+            "description": "Expected success: 201 Created. Returns id, email, created_at."
+          },
+          "response": []
+        },
+        {
+          "name": "Login",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Status is 200', function () {",
+                  "    pm.response.to.have.status(200);",
+                  "});",
+                  "const json = pm.response.json();",
+                  "pm.test('access_token exists', function () {",
+                  "    pm.expect(json.access_token).to.be.a('string');",
+                  "});",
+                  "if (json.access_token) {",
+                  "    pm.collectionVariables.set('token', json.access_token);",
+                  "}"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [{ "key": "Content-Type", "value": "application/json" }],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"email\": \"{{email}}\",\n  \"password\": \"{{password}}\"\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/auth/login",
+              "host": ["{{baseUrl}}"],
+              "path": ["auth", "login"]
+            },
+            "description": "Expected success: 200 OK. Saves access_token into collection variable {{token}}."
+          },
+          "response": []
+        },
+        {
+          "name": "Me",
+          "request": {
+            "auth": {
+              "type": "bearer",
+              "bearer": [
+                { "key": "token", "value": "{{token}}", "type": "string" }
+              ]
+            },
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/me",
+              "host": ["{{baseUrl}}"],
+              "path": ["me"]
+            },
+            "description": "Expected success: 200 OK. Returns current authenticated user."
+          },
+          "response": []
+        }
+      ]
+    },
+    {
+      "name": "Facilities",
+      "item": [
+        {
+          "name": "List Facilities",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/facilities",
+              "host": ["{{baseUrl}}"],
+              "path": ["facilities"]
+            },
+            "description": "Expected success: 200 OK. Returns available facilities."
+          },
+          "response": []
+        }
+      ]
+    },
+    {
+      "name": "Reservations",
+      "item": [
+        {
+          "name": "List My Reservations",
+          "request": {
+            "auth": {
+              "type": "bearer",
+              "bearer": [
+                { "key": "token", "value": "{{token}}", "type": "string" }
+              ]
+            },
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/reservations",
+              "host": ["{{baseUrl}}"],
+              "path": ["reservations"]
+            },
+            "description": "Expected success: 200 OK. Returns only the authenticated user's reservations."
+          },
+          "response": []
+        },
+        {
+          "name": "Create Reservation",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Status is 201', function () {",
+                  "    pm.response.to.have.status(201);",
+                  "});",
+                  "const json = pm.response.json();",
+                  "pm.test('Reservation id exists', function () {",
+                  "    pm.expect(json.id).to.exist;",
+                  "});",
+                  "if (json.id) {",
+                  "    pm.collectionVariables.set('reservationId', String(json.id));",
+                  "}"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "auth": {
+              "type": "bearer",
+              "bearer": [
+                { "key": "token", "value": "{{token}}", "type": "string" }
+              ]
+            },
+            "method": "POST",
+            "header": [{ "key": "Content-Type", "value": "application/json" }],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"facility_id\": {{facilityId}},\n  \"start_time\": \"{{startTime}}\",\n  \"end_time\": \"{{endTime}}\"\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/reservations",
+              "host": ["{{baseUrl}}"],
+              "path": ["reservations"]
+            },
+            "description": "Expected success: 201 Created. Saves returned reservation id into {{reservationId}}."
+          },
+          "response": []
+        },
+        {
+          "name": "Get Reservation By Id",
+          "request": {
+            "auth": {
+              "type": "bearer",
+              "bearer": [
+                { "key": "token", "value": "{{token}}", "type": "string" }
+              ]
+            },
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/reservations/{{reservationId}}",
+              "host": ["{{baseUrl}}"],
+              "path": ["reservations", "{{reservationId}}"]
+            },
+            "description": "Expected success: 200 OK. Returns one reservation for the owner."
+          },
+          "response": []
+        },
+        {
+          "name": "Delete Reservation",
+          "request": {
+            "auth": {
+              "type": "bearer",
+              "bearer": [
+                { "key": "token", "value": "{{token}}", "type": "string" }
+              ]
+            },
+            "method": "DELETE",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/reservations/{{reservationId}}",
+              "host": ["{{baseUrl}}"],
+              "path": ["reservations", "{{reservationId}}"]
+            },
+            "description": "Expected success: 200 OK. Reservation status becomes canceled."
+          },
+          "response": []
+        }
+      ]
+    }
+  ]
+}

--- a/docs/api/mvp-api.postman_environment.json
+++ b/docs/api/mvp-api.postman_environment.json
@@ -1,0 +1,42 @@
+{
+  "id": "b4e44c0d-4d90-47cb-8a9b-mpi-mvp-env",
+  "name": "MPI Court Reservations - Local",
+  "values": [
+    {
+      "key": "baseUrl",
+      "value": "http://127.0.0.1:8000",
+      "type": "default",
+      "enabled": true
+    },
+    { "key": "token", "value": "", "type": "default", "enabled": true },
+    { "key": "reservationId", "value": "", "type": "default", "enabled": true },
+    {
+      "key": "email",
+      "value": "usera@example.com",
+      "type": "default",
+      "enabled": true
+    },
+    {
+      "key": "password",
+      "value": "password123",
+      "type": "default",
+      "enabled": true
+    },
+    { "key": "facilityId", "value": "1", "type": "default", "enabled": true },
+    {
+      "key": "startTime",
+      "value": "2026-05-01T10:00:00Z",
+      "type": "default",
+      "enabled": true
+    },
+    {
+      "key": "endTime",
+      "value": "2026-05-01T11:00:00Z",
+      "type": "default",
+      "enabled": true
+    }
+  ],
+  "_postman_variable_scope": "environment",
+  "_postman_exported_at": "2026-04-19T00:00:00.000Z",
+  "_postman_exported_using": "OpenAI ChatGPT"
+}


### PR DESCRIPTION
## Summary

- added a Postman collection for the MVP API endpoints
- added a Postman environment for local testing
- included auth, facilities, and reservation requests
- included reusable variables such as `baseUrl`, `token`, and `reservationId`

## Behavior (Acceptance Criteria)

- collection includes:
  - `POST /auth/register`
  - `POST /auth/login`
  - `GET /me`
  - `GET /facilities`
  - `GET /reservations`
  - `POST /reservations`
  - `GET /reservations/{id}`
  - `DELETE /reservations/{id}`
- environment includes:
  - `baseUrl`
  - `token`
  - `reservationId`
- requests include example payloads and expected behavior notes
- files are committed under `docs/api/`

## Manual testing

- reviewed the collection structure and request coverage
- confirmed the collection matches the current MVP API endpoints

Closes #36