### PR TITLE
QA: add auth integration tests

### DIFF
--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+from tests.conftest import auth_headers, create_user, login_and_get_token
+
+
+def assert_error(response, status_code: int, error_code: str, message: str) -> None:
+    assert response.status_code == status_code
+    body = response.json()
+    assert body["error_code"] == error_code
+    assert body["message"] == message
+    assert body["details"] is None
+
+
+def test_register_valid_user_returns_201(client):
+    response = client.post(
+        "/auth/register",
+        json={
+            "email": "newuser@example.com",
+            "password": "password123",
+        },
+    )
+
+    assert response.status_code == 201
+    body = response.json()
+    assert body["email"] == "newuser@example.com"
+    assert "id" in body
+    assert "created_at" in body
+
+
+def test_register_duplicate_email_returns_409(client):
+    create_user(client, "duplicate@example.com")
+
+    response = client.post(
+        "/auth/register",
+        json={
+            "email": "duplicate@example.com",
+            "password": "password123",
+        },
+    )
+
+    assert_error(
+        response,
+        409,
+        "conflict",
+        "Email already registered",
+    )
+
+
+def test_login_valid_credentials_returns_200(client):
+    create_user(client, "login@example.com")
+
+    response = client.post(
+        "/auth/login",
+        json={
+            "email": "login@example.com",
+            "password": "password123",
+        },
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert isinstance(body["access_token"], str)
+    assert body["access_token"]
+    assert body["token_type"] == "bearer"
+
+
+def test_login_invalid_credentials_returns_401(client):
+    create_user(client, "wrongpass@example.com")
+
+    response = client.post(
+        "/auth/login",
+        json={
+            "email": "wrongpass@example.com",
+            "password": "wrongpassword",
+        },
+    )
+
+    assert_error(
+        response,
+        401,
+        "unauthorized",
+        "Invalid credentials",
+    )
+
+
+def test_me_with_valid_token_returns_200(client):
+    create_user(client, "me@example.com")
+    token = login_and_get_token(client, "me@example.com")
+
+    response = client.get(
+        "/me",
+        headers=auth_headers(token),
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["email"] == "me@example.com"
+    assert "id" in body
+    assert "created_at" in body
+
+
+def test_me_without_token_returns_401(client):
+    response = client.get("/me")
+
+    assert_error(
+        response,
+        401,
+        "unauthorized",
+        "Not authenticated",
+    )


### PR DESCRIPTION
## Summary

- added dedicated backend auth integration tests in `backend/tests/test_auth.py`
- covered register, login, and `/me`
- covered both valid and invalid auth cases

## Behavior (Acceptance Criteria)

- added a dedicated backend auth integration test file
- includes:
  - valid register (`201`)
  - duplicate email register (`409`)
  - valid login (`200`)
  - invalid credentials (`401`)
  - `GET /me` with valid token (`200`)
  - `GET /me` without token (`401`)
- tests use the existing pytest / FastAPI TestClient setup
- tests pass locally with `pytest`

## Manual testing

- ran:
  ```bash
  pytest backend/tests/test_auth.py